### PR TITLE
pstep relation, pstep_flush termination proof

### DIFF
--- a/src/theory/bir/HolBACoreSimps.sml
+++ b/src/theory/bir/HolBACoreSimps.sml
@@ -33,6 +33,7 @@ val bir_list_of_types = [
    mk_thy_type {Tyop="bir_program_t",        Thy="bir_program", Args=[Type.alpha]},
    mk_thy_type {Tyop="bir_programcounter_t", Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_status_t",         Thy="bir_program", Args=[]},
+   mk_thy_type {Tyop="bir_inflight_stmt_t",  Thy="bir_program", Args=[Type.alpha]},
    mk_thy_type {Tyop="bir_state_t",          Thy="bir_program", Args=[]},
    mk_thy_type {Tyop="bir_execution_result_t", Thy="bir_program", Args=[Type.alpha]}
 ];

--- a/src/theory/bir/bir_multicoreScript.sml
+++ b/src/theory/bir/bir_multicoreScript.sml
@@ -70,15 +70,16 @@ val bir_compute_steps_defn = Hol_defn "bir_compute_steps" `bir_compute_steps (n:
 
 (* Defn.tgoal bir_compute_steps_defn *)
 val (bir_compute_steps_def, bir_compute_steps_ind) = Defn.tprove (bir_compute_steps_defn,
-WF_REL_TAC `measure (\ (n,_,_). n)`);
+  WF_REL_TAC `measure (\ (n,_,_). n)`
+);
 
 val bir_next_states_def = Define `bir_next_states p s =
   { s2 | pstep p s s2 }
 `;
 
 val (is_trace_rules, is_trace_ind, is_trace_cases) = Hol_reln `
-(!p s. is_trace p [s]) /\
-(!p s2 s1 t . ((is_trace p (APPEND t [s1])) /\ (pstep p s1 s2))
+  (!p s. is_trace p [s]) /\
+  (!p s2 s1 t. ((is_trace p (APPEND t [s1])) /\ (pstep p s1 s2))
     ==> (is_trace p (APPEND t [s1;s2])))
 `;
 

--- a/src/theory/bir/bir_programScript.sml
+++ b/src/theory/bir/bir_programScript.sml
@@ -1,4 +1,3 @@
-
 open HolKernel Parse boolLib bossLib;
 open wordsTheory bitstringTheory;
 open bir_auxiliaryTheory bir_immTheory bir_valuesTheory;


### PR DESCRIPTION
This PR contains a [slight change](https://github.com/pablobuiras/HolBA/blob/dev_didrikl_multicore/src/theory/bir/bir_multicoreScript.sml#L29-L44) in the definition of `bir_pstep`. Previously, the only way to fetch statements into the pipeline meant incrementing the PC index by 1. Now, this is possible only if the current statement is a basic statement, preventing transitions outside of a block to be legal. Furthermore, a new clause is added which permits pipelining to continue from one BIR block to the next, provided branching is avoided.

There is also a [complete termination proof](https://github.com/pablobuiras/HolBA/blob/dev_didrikl_multicore/src/theory/bir/bir_multicoreScript.sml#L135-L213) for `pstep_flush`.

Also, new type rewrites were added to the standard HolBA simplification sets.

Other changes are cosmetic or supplements to enable the above.