### PR TITLE
Made new wrapper for riscv_stepLib

### DIFF
--- a/src/tools/lifter/bir_lifting_machinesLib_instances.sml
+++ b/src/tools/lifter/bir_lifting_machinesLib_instances.sml
@@ -17,6 +17,8 @@ open bir_lifting_machinesLib bir_inst_liftingHelpersLib
 (* Function libraries from examples/l3-machine-code: *)
 open arm8_stepLib m0_stepLib riscv_stepLib;
 
+open riscv_step_wrapperLib;
+
 (* Abbreviations used in this file:
  * BMR: BIR machine record. *)
 
@@ -641,8 +643,7 @@ local
   val simp_conv = SIMP_CONV std_ss [riscv_extra_FOLDS]
 
   val simp_conv2 =
-    (SIMP_CONV (arith_ss++wordsLib.WORD_ARITH_ss++
-                wordsLib.WORD_LOGIC_ss) []
+    (SIMP_CONV arith_ss []
     ) THENC
     (SIMP_CONV std_ss
                [bir_riscv_extrasTheory.word_add_to_sub_TYPES,
@@ -736,13 +737,15 @@ in
   val vn = mk_var ("ms", ms_ty);
   val hex_code = "FCE14083" (* "lbu x1,x2,-50" *)
 
+  val hex_code = "0052C3B3" (* "xor x7,x5,x5" *)
+
   val hex_code = "340090F3" (* "csrrw x1,mscratch, x1" *)
 
 *)
   fun riscv_step_hex' vn hex_code = let
     val pc_mem_thms = prepare_mem_contains_thms vn hex_code
 
-    val step_thms0 = [riscv_step_hex hex_code]
+    val step_thms0 = [(riscv_step_rem_ss_hex ["word arith", "word ground", "word logic", "word shift", "word subtract"]) hex_code]
     val step_thms1 =
       List.map (process_riscv_thm vn pc_mem_thms) step_thms0
   in

--- a/src/tools/lifter/riscv_step_wrapper/COPYRIGHT
+++ b/src/tools/lifter/riscv_step_wrapper/COPYRIGHT
@@ -1,0 +1,56 @@
+HOL COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+
+Copyright 1985--2021 by the HOL4 CONTRIBUTORS
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * The names of the copyright holders and contributors may not be
+    used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+----------------------------------------------------------------------
+
+Some files we distribute with HOL are the work of others, and we do
+not and cannot claim copyright over them. Their copyrights may differ
+from the above, but permit us to redistribute them. Such files
+generally self-identify. In addition, we explicitly list the following
+sub-directories as containing files governed by different copyright
+notices.
+
+See
+  examples/muddy/LICENSE
+  examples/muddy/muddyC/buddy/README
+  examples/machine-code/graph/seL4-kernel/README
+  src/HolSat/sat_solvers/minisat
+
+- Files derived from SML/NJ are governed by the notice in
+     doc/copyrights/smlnj.txt
+
+- Some contributions have been explicitly put into the public domain
+  by their authors: we cannot claim copyright on them individually. We
+  have attempted to list these files in
+     doc/copyrights/public-domain-contributions.txt.
+----------------------------------------------------------------------

--- a/src/tools/lifter/riscv_step_wrapper/Holmakefile.gen
+++ b/src/tools/lifter/riscv_step_wrapper/Holmakefile.gen
@@ -14,12 +14,12 @@ DEPENDENCIES   =
 
 # configuration
 # ----------------------------------
-HOLHEAP        = riscv_step_wrapper/HolBATools_Lifter_riscv_step_wrapper-heap
-NEWHOLHEAP     = HolBATools_Lifter-heap
+HOLHEAP        = ../../../shared/HolBAShared-heap
+NEWHOLHEAP     = HolBATools_Lifter_riscv_step_wrapper-heap
 
 HEAPINC_EXTRA  = 
 
 
 # included lines follow
 # ----------------------------------
-include ../../Holmakefile.inc
+include ../../../Holmakefile.inc

--- a/src/tools/lifter/riscv_step_wrapper/riscv_step_wrapperLib.sig
+++ b/src/tools/lifter/riscv_step_wrapper/riscv_step_wrapperLib.sig
@@ -1,0 +1,5 @@
+signature riscv_step_wrapperLib =
+sig
+   val riscv_step_rem_ss : string list -> Term.term -> Thm.thm
+   val riscv_step_rem_ss_hex : string list -> string -> Thm.thm
+end

--- a/src/tools/lifter/riscv_step_wrapper/riscv_step_wrapperLib.sml
+++ b/src/tools/lifter/riscv_step_wrapper/riscv_step_wrapperLib.sml
@@ -1,0 +1,159 @@
+(* Adapted from HOL4 examples - see COPYRIGHT file in this directory *)
+
+structure riscv_step_wrapperLib :> riscv_step_wrapperLib =
+struct
+
+open HolKernel boolLib bossLib;
+open blastLib riscvTheory riscv_stepTheory riscv_stepLib;
+
+structure Parse = struct
+  open Parse
+  val (Type, Term) = parse_from_grammars riscv_stepTheory.riscv_step_grammars
+end
+open Parse
+
+val ERR = Feedback.mk_HOL_ERR "riscv_stepLib"
+
+val s = ``s:riscv_state``
+
+local
+  val i16 = fcpSyntax.mk_int_numeric_type 16
+  val i32 = fcpSyntax.mk_int_numeric_type 32
+  val x = Term.mk_var ("x", ``:rawInstType``)
+  fun padded_opcode v =
+    let
+      val (l, ty) = listSyntax.dest_list v
+      val () = ignore (ty = Type.bool andalso List.length l <= 32 orelse
+               raise ERR "mk_opcode" "bad opcode")
+      fun ends_in_TT [] = false
+        | ends_in_TT [x] = false
+        | ends_in_TT [x,y] = aconv x y andalso aconv x boolSyntax.T
+        | ends_in_TT (x::xs) = ends_in_TT xs
+    in
+      if ends_in_TT l then
+        listSyntax.mk_list (utilsLib.padLeft boolSyntax.F 32 l, ty)
+      else
+        listSyntax.mk_list (utilsLib.padLeft boolSyntax.F 16 l, ty)
+    end
+  fun pad_opcode v =
+    let
+      val xs = padded_opcode v
+      val (l,ty) = listSyntax.dest_list xs
+    in
+      if length l < 32 then mk_comb(``Half``,bitstringSyntax.mk_v2w (xs, i16))
+                       else mk_comb(``Word``,bitstringSyntax.mk_v2w (xs, i32))
+    end
+in
+  val padded_opcode = padded_opcode
+  fun fetch v = let
+    val vs = pad_opcode v
+    val lemma = if can (match_term ``Word _``) vs
+                then riscv_stepTheory.Fetch32 else riscv_stepTheory.Fetch16
+    val bs = vs |> rand |> rand
+    in lemma |> SPEC bs |> SIMP_RULE std_ss [listTheory.CONS_11]
+             |> REWRITE_RULE [GSYM AND_IMP_INTRO] |> UNDISCH_ALL end
+  val fetch_hex = fetch o bitstringSyntax.bitstring_of_hexstring
+end
+
+val STATE_CONV =
+  Conv.QCONV
+    (REWRITE_CONV
+       ([ASSUME ``^s.exception = riscv$NoException``,
+         ASSUME ``^s.c_NextFetch ^s.procID = NONE``,
+         riscv_stepTheory.update_pc, updateTheory.UPDATE_EQ] @
+        utilsLib.datatype_rewrites true "riscv" ["riscv_state"]))
+
+val state_rule = Conv.RIGHT_CONV_RULE STATE_CONV
+val full_state_rule = utilsLib.ALL_HYP_CONV_RULE STATE_CONV o state_rule
+
+val fetch_inst =
+  Thm.INST []
+
+local
+  val rwts = List.map (full_state_rule o fetch_inst o DB.fetch "riscv_step")
+               riscv_stepTheory.rwts
+  val fnd = utilsLib.find_rw (utilsLib.mk_rw_net utilsLib.lhsc rwts)
+  val rule = Conv.DEPTH_CONV wordsLib.word_EQ_CONV
+             THENC REWRITE_CONV [riscv_stepTheory.v2w_0_rwts]
+  val eval_simp_rule =
+    utilsLib.ALL_HYP_CONV_RULE rule o Conv.CONV_RULE (Conv.RHS_CONV rule)
+  fun eval tm rwt =
+    let
+      val thm = eval_simp_rule (utilsLib.INST_REWRITE_CONV1 rwt tm)
+    in
+      if utilsLib.vacuous thm then NONE else SOME thm
+    end
+  val neg_count = List.length o List.filter boolSyntax.is_neg o Thm.hyp
+  fun err tm s = ( Parse.print_term tm; print "\n"; raise ERR "run" s )
+in
+  fun run tm =
+    (case List.mapPartial (eval tm) (fnd tm) of
+        [] => err tm "no valid step theorem"
+      | [x] => x
+      | l => List.last (mlibUseful.sort_map neg_count Int.compare l))
+    handle HOL_ERR {message = "not found", origin_function = "find_rw", ...} =>
+      err tm "instruction instance not supported"
+end
+
+
+local
+  fun mk_proj s =
+    Lib.curry Term.mk_comb
+      (Term.prim_mk_const {Thy = "riscv", Name = "riscv_state_" ^ s})
+  fun proj f = STATE_CONV o f o utilsLib.rhsc
+  val proj_exception = proj (mk_proj "exception")
+  val proj_NextFetch = mk_proj "c_NextFetch"
+  val proj_procID = mk_proj "procID"
+  val proj_NextFetch_procID =
+    proj (fn tm => Term.mk_comb (proj_NextFetch tm, proj_procID tm))
+  val ap_snd = Thm.AP_TERM ``SND: unit # riscv_state -> riscv_state``
+  val snd_conv = Conv.REWR_CONV pairTheory.SND
+  fun spec_run thm3 ethm =
+    Conv.RIGHT_CONV_RULE
+      (Conv.RAND_CONV (Conv.REWR_CONV ethm) THENC snd_conv) (ap_snd thm3)
+  fun next th = PURE_REWRITE_RULE [word_bit_0_lemmas] o state_rule o Drule.MATCH_MP th
+  val MP_Next_n = next riscv_stepTheory.NextRISCV
+  val MP_Next_c = next riscv_stepTheory.NextRISCV_cond_branch
+  val MP_Next_b = next riscv_stepTheory.NextRISCV_branch
+  val Run_CONV = utilsLib.Run_CONV ("riscv", s) o utilsLib.rhsc
+  fun tidy_up_signalAddressException th ss_rem =
+    let
+      val rw = UNDISCH avoid_signalAddressException
+      fun FORCE_REWR_CONV rw tm =
+        let
+          val (p,_) = match_term (rw |> concl |> rator |> rand) tm
+        in INST p rw end handle HOL_ERR _ => NO_CONV tm;
+    in
+      CONV_RULE (DEPTH_CONV (FORCE_REWR_CONV rw)) th
+      |> DISCH_ALL |> SIMP_RULE std_ss [word_bit_add_lsl_simp]
+      |> SIMP_RULE (simpLib.remove_ssfrags ss_rem (srw_ss())) [] |> UNDISCH_ALL
+    end
+in
+  fun riscv_step' ss_rem v =
+    let
+      val thm1 = fetch v
+      val thm2 = riscv_decode v |> SIMP_RULE std_ss []
+      val new_s = thm1 |> concl |> rand |> rand
+      val thm3 = fetch_inst (Drule.SPEC_ALL (Run_CONV thm2)) |> INST [s |-> new_s]
+      val tm = utilsLib.rhsc thm3
+      val ethm = run tm
+      val ethm = tidy_up_signalAddressException ethm ss_rem
+      val thm4 = Conv.RIGHT_CONV_RULE (Conv.REWR_CONV ethm) thm3
+      val thm5 = proj_exception thm4
+      val thm6 = proj_NextFetch_procID thm4
+      val thm = Drule.LIST_CONJ [thm1, thm2, thm4, thm5, thm6]
+      val tm = utilsLib.rhsc thm6
+    in
+      if optionSyntax.is_none tm
+        then MP_Next_n thm
+      else if boolSyntax.is_cond tm
+        then MP_Next_c thm
+      else MP_Next_b thm
+    end
+end
+
+fun riscv_step_rem_ss ss_rem = riscv_step' ss_rem;
+
+fun riscv_step_rem_ss_hex ss_rem = (riscv_step' ss_rem) o bitstringSyntax.bitstring_of_hexstring;
+
+end

--- a/src/tools/lifter/selftest_riscv.log
+++ b/src/tools/lifter/selftest_riscv.log
@@ -408,8 +408,9 @@ ANDI x15,x1,5: 0050F793 @ 0x10030 - OK
            bb_atomic := F;
            bb_statements :=
              [BStmt_Assign (BVar "x15" (BType_Imm Bit64))
-                (BExp_BinExp BIExp_And (BExp_Const (Imm64 5w))
-                   (BExp_Den (BVar "x1" (BType_Imm Bit64))))];
+                (BExp_BinExp BIExp_And
+                   (BExp_Den (BVar "x1" (BType_Imm Bit64)))
+                   (BExp_Const (Imm64 5w)))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -468,8 +469,8 @@ ADD x5, x6, x7: 007302B3 @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Plus
-                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -482,11 +483,9 @@ SUB x5, x6, x7: 407302B3 @ 0x10030 - OK
            bb_atomic := F;
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
-                (BExp_BinExp BIExp_Plus
-                   (BExp_BinExp BIExp_Mult
-                      (BExp_Const (Imm64 0xFFFFFFFFFFFFFFFFw))
-                      (BExp_Den (BVar "x7" (BType_Imm Bit64))))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                (BExp_BinExp BIExp_Minus
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -548,8 +547,8 @@ XOR x5, x6, x7: 007342B3 @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Xor
-                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -595,8 +594,8 @@ OR x5, x6, x7: 007362B3 @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Or
-                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -610,8 +609,8 @@ AND x5, x6, x7: 007372B3 @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_And
-                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -797,8 +796,8 @@ ADDW x5, x6, x7: 007302BB @ 0x10030 - OK
                 (BExp_Cast BIExp_SignedCast
                    (BExp_Cast BIExp_LowCast
                       (BExp_BinExp BIExp_Plus
-                         (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                         (BExp_Den (BVar "x6" (BType_Imm Bit64)))) Bit32)
+                         (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                         (BExp_Den (BVar "x7" (BType_Imm Bit64)))) Bit32)
                    Bit64)];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
@@ -813,13 +812,11 @@ SUBW x5, x6, x7: 407302BB @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_Cast BIExp_SignedCast
-                   (BExp_BinExp BIExp_Plus
-                      (BExp_BinExp BIExp_Mult
-                         (BExp_Const (Imm32 0xFFFFFFFFw))
-                         (BExp_Cast BIExp_LowCast
-                            (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
+                   (BExp_BinExp BIExp_Minus
                       (BExp_Cast BIExp_LowCast
-                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32))
+                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32)
+                      (BExp_Cast BIExp_LowCast
+                         (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                    Bit64)];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
@@ -923,8 +920,8 @@ MUL x5, x6, x7: 027302B3 @ 0x10030 - OK
            bb_statements :=
              [BStmt_Assign (BVar "x5" (BType_Imm Bit64))
                 (BExp_BinExp BIExp_Mult
-                   (BExp_Den (BVar "x7" (BType_Imm Bit64)))
-                   (BExp_Den (BVar "x6" (BType_Imm Bit64))))];
+                   (BExp_Den (BVar "x6" (BType_Imm Bit64)))
+                   (BExp_Den (BVar "x7" (BType_Imm Bit64))))];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
@@ -940,9 +937,9 @@ MULH x5, x6, x7: 027312B3 @ 0x10030 - OK
                 (BExp_Cast BIExp_HighCast
                    (BExp_BinExp BIExp_Mult
                       (BExp_Cast BIExp_SignedCast
-                         (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit128)
+                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128)
                       (BExp_Cast BIExp_SignedCast
-                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128))
+                         (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit128))
                    Bit64)];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
@@ -978,9 +975,9 @@ MULHU x5, x6, x7: 027332B3 @ 0x10030 - OK
                 (BExp_Cast BIExp_HighCast
                    (BExp_BinExp BIExp_Mult
                       (BExp_Cast BIExp_UnsignedCast
-                         (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit128)
+                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128)
                       (BExp_Cast BIExp_UnsignedCast
-                         (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit128))
+                         (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit128))
                    Bit64)];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
@@ -1106,9 +1103,9 @@ MULW x5, x6, x7: 027302BB @ 0x10030 - OK
                       (BExp_Cast BIExp_SignedCast
                          (BExp_BinExp BIExp_Mult
                             (BExp_Cast BIExp_LowCast
-                               (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32)
+                               (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32)
                             (BExp_Cast BIExp_LowCast
-                               (BExp_Den (BVar "x6" (BType_Imm Bit64))) Bit32))
+                               (BExp_Den (BVar "x7" (BType_Imm Bit64))) Bit32))
                          Bit64) Bit32) Bit64)];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])


### PR DESCRIPTION
This should solve the oversimplification problems we had with instructions like `xor x7, x5, x5`. Please comment on the copyright solution.