### PR TITLE
Small fixes related to promising semantics

### DIFF
--- a/src/theory/bir/bir_programScript.sml
+++ b/src/theory/bir/bir_programScript.sml
@@ -253,6 +253,7 @@ val bir_state_init_def = Define `bir_state_init p = <|
   ; bst_inflight := []
   ; bst_counter := 0
   ; bst_fwdb := (\l. <| fwdb_time:= 0; fwdb_view:=0; fwdb_xcl:=F |>)
+  ; bst_xclb := NONE
 |>`;
 
 (* ------------------------------------------------------------------------- *)

--- a/src/tools/lifter/selftest_riscv.log
+++ b/src/tools/lifter/selftest_riscv.log
@@ -633,8 +633,7 @@ FENCE.TSO: 8331008F @ 0x10030 - OK - cheat
         [<|bb_label := BL_Address_HC (Imm64 0x10030w) "8331008F";
            bb_atomic := T;
            bb_statements :=
-             [BStmt_Fence BM_Read BM_ReadWrite;
-              BStmt_Fence BM_Write BM_Write];
+             [BStmt_Fence BM_Read BM_Read; BStmt_Fence BM_ReadWrite BM_Write];
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 


### PR DESCRIPTION
* RISC-V selftest is now updated to take the `fence.tso` changes into account, so it won't erroneously fail in the CI
* The exclusive bank `xclb` is now properly initialised in `bir_state_init`