### PR TITLE
Fixed lifting of stores storing value in zero register

### DIFF
--- a/src/tools/lifter/bir_inst_liftingLib.sml
+++ b/src/tools/lifter/bir_inst_liftingLib.sml
@@ -217,7 +217,7 @@ open bir_lifterSimps;
 
   in
     LIST_CONJ (
-     (mk_lift_thm mr_mem_lf_of_ms) :: (* RISC-V TODO: OK. *)
+     (mk_lift_thm mr_mem_lf_of_ms) ::
      (mk_lift_thm (rand mr_pc_lf_of_ms)) ::
      map (mk_lift_thm o rand o snd) mr_imms_lf_of_ms)
   end;
@@ -240,17 +240,19 @@ open bir_lifterSimps;
 (* For debugging RISC-V:
   (* TODO: Make shortcuts for debugging other things than preconds *)
 
-  val hex_code = String.map Char.toUpper "FCE0879B"; (* "addiw x15,x1,-50" *)
+  val hex_code = String.map Char.toUpper "0003A023"; (* sw x0, 0(t2) *)
+  val hex_code = String.map Char.toUpper "00E12423"; (* sw x14, 8(x2) *)
 
   val hex_code_desc = hex_code;
-  val (next_thms, mm_tm, label_tm) = mk_inst_lifting_theorems hex_code hex_code_desc
+  val is_multicore = false;
+  val (next_thms, mm_tm, label_tm) = mk_inst_lifting_theorems hex_code hex_code_desc is_multicore
   val (lb, ms_case_cond_t, next_thm) = el 1 (preprocess_next_thms label_tm next_thms)
   val next_thm0 = REWRITE_RULE [ASSUME ms_case_cond_t] next_thm
   val (preconds, next_tm) = strip_imp_only (concl next_thm0)
   val tm = (* Put term returned by exception here, don't forget type information... *)
 
-val tm = ``Imm64
-                (w2w ((riscv_mem_half ms.MEM8 (ms.c_gpr ms.procID 2w - 50w)):word16))``;
+val tm = ``riscv_mem_store_word (ms.c_gpr ms.procID 7w + 0w) 0w ms.MEM8``;
+val tm = ``riscv_mem_store_word (ms.c_gpr ms.procID 2w + 8w) (ms.c_gpr ms.procID 14w) ms.MEM8``;
 
   (* In case of several preconds, continue with the following for 2, 3, 4, ...*)
   (* val tm = el 2 preconds *)
@@ -1327,7 +1329,7 @@ fun get_patched_step_hex ms_v hex_code is_multicore =
   (* Lifting an instruction *)
   (**************************)
 
-  (* Lifting single instructings, is the main workhorse of this library.
+  (* Lifting single instructions, is the main workhorse of this library.
      The top-level interface provides a function "bir_lift_instr" that given
 
      - a memory region not to touch
@@ -1388,8 +1390,11 @@ fun get_patched_step_hex ms_v hex_code is_multicore =
 (* For debugging RISC-V:
 
   val (mu_thm:thm, mm_precond_thm:thm) = test_RISCV.bir_lift_instr_prepare_mu_thms (mu_b, mu_e)
+  val hex_code = String.map Char.toUpper "0003A023"; (* sw x0, 0(t2) *)
+  val hex_code = String.map Char.toUpper "00E12423"; (* sw x14, 8(x2) *)
   val hex_code = String.map Char.toUpper "007302B3";
   val hex_code_desc = hex_code;
+  val is_multicore = false;
 
 *)
   fun bir_lift_instr_mu_gen_pc_compute (mu_thm:thm, mm_precond_thm : thm) hex_code hex_code_desc is_multicore =

--- a/src/tools/lifter/bir_lifting_machinesLib_instances.sml
+++ b/src/tools/lifter/bir_lifting_machinesLib_instances.sml
@@ -705,7 +705,7 @@ local
    * into a more manageable format. *)
   (* DEBUG (when called from riscv_step_hex')
    
-     val thm = hd step_thms0 
+       val thm = hd step_thms0
 
   *)
   fun process_riscv_thm is_multicore vn pc_mem_thms thm = let
@@ -756,6 +756,7 @@ in
 
   val (ms_ty, addr_sz_ty, mem_val_sz_ty)  = dest_bir_lifting_machine_rec_t_ty (type_of (prim_mk_const{Name="riscv_bmr", Thy="bir_lifting_machines"}))
   val vn = mk_var ("ms", ms_ty);
+  val is_multicore = false;
   val hex_code = "FCE14083" (* "lbu x1,x2,-50" *)
 
   val hex_code = "340090F3" (* "csrrw x1,mscratch, x1" *)
@@ -764,11 +765,16 @@ in
 
   val hex_code = "00029263" (* "bne x5, x0, 4" *)
 
+  val hex_code = "00E12423" (* "sw x14, 8(x2)" *)
+
+  val hex_code = "0003A023" (* "sw x0, 0(t2)" *)
+
 *)
   fun riscv_step_hex' is_multicore vn hex_code = let
     val pc_mem_thms = prepare_mem_contains_thms vn hex_code
 
     val step_thms0 = [(riscv_step_rem_ss_hex ["word arith", "word ground", "word logic", "word shift", "word subtract"]) hex_code]
+
     val step_thms1 =
       List.map (process_riscv_thm is_multicore vn pc_mem_thms) step_thms0
   in

--- a/src/tools/lifter/selftest_riscv.log
+++ b/src/tools/lifter/selftest_riscv.log
@@ -322,6 +322,33 @@ SW x14, 8(x2): 00E12423 @ 0x10030 - OK
            bb_last_statement :=
              BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
 
+SW x0, 0(t2): 0003A023 @ 0x10030 - OK
+ []
+|- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
+     (0x10030w,[35w; 160w; 3w; 0w])
+     (BirProgram
+        [<|bb_label := BL_Address_HC (Imm64 0x10030w) "0003A023";
+           bb_mc_tags := NONE;
+           bb_statements :=
+             [BStmt_Assert
+                (BExp_Aligned Bit64 2
+                   (BExp_BinExp BIExp_Plus
+                      (BExp_Den (BVar "x7" (BType_Imm Bit64)))
+                      (BExp_Const (Imm64 0w))));
+              BStmt_Assert
+                (BExp_unchanged_mem_interval_distinct Bit64 0 16777216
+                   (BExp_BinExp BIExp_Plus
+                      (BExp_Den (BVar "x7" (BType_Imm Bit64)))
+                      (BExp_Const (Imm64 0w))) 4);
+              BStmt_Assign (BVar "MEM8" (BType_Mem Bit64 Bit8))
+                (BExp_Store (BExp_Den (BVar "MEM8" (BType_Mem Bit64 Bit8)))
+                   (BExp_BinExp BIExp_Plus
+                      (BExp_Den (BVar "x7" (BType_Imm Bit64)))
+                      (BExp_Const (Imm64 0w))) BEnd_LittleEndian
+                   (BExp_Cast BIExp_LowCast (BExp_Const (Imm64 0w)) Bit32))];
+           bb_last_statement :=
+             BStmt_Jmp (BLE_Label (BL_Address (Imm64 0x10034w)))|>])
+
 ADDI x15,x1,-50: FCE08793 @ 0x10030 - OK
  []
 |- bir_is_lifted_inst_prog riscv_bmr (Imm64 0x10030w) (WI_end 0w 0x1000000w)
@@ -2020,7 +2047,7 @@ AMOMAXU.D x1, x3, (x2): E03130AF @ 0x10030 - OK - cheat
 SUMMARY FAILING HEXCODES RISC-V
 
 
-Instructions FAILED: 8/98
+Instructions FAILED: 8/99
 
    "3400F0F3" (* bmr_step_hex failed *),
    "3400E0F3" (* bmr_step_hex failed *),

--- a/src/tools/lifter/selftest_riscv.sml
+++ b/src/tools/lifter/selftest_riscv.sml
@@ -24,7 +24,6 @@ end;
 structure test_RISCV = test_bmr(structure MD = bmil_riscv; structure log_name_str = log_name);
 
 
-(* TODO: Double-check these numbers are OK, should work with arbitrary ones though *)
 val mu_b = Arbnum.fromInt 0; (* Memory starts at address 0x0 *)
 val mu_e = Arbnum.fromInt 0x1000000; (* Memory ends at address 0x1000000 *)
 val pc =   Arbnum.fromInt 0x10030; (* Program counter is at address 0x10030 *)
@@ -77,16 +76,7 @@ val riscv_test_asms = map riscv_test_asm
 val _ = print_msg "\n";
 val _ = print_header "MANUAL TESTS (HEX) - RISC-V\nRV64I Base Instruction Set (instructions inherited from RV32I)\n";
 val _ = print_msg "\n";
-(* Good presentation of RISC-V instructions at https://inst.eecs.berkeley.edu/~cs61c/sp19/lectures/lec05.pdf *)
-(* 75 instructions in initial scope (including M extension) *)
-(* 10 still TODO:
- *  2 fences
- *  environment call and breakpoint
- *  6 CSR instructions *)
 (* TODO: Instructions from privileged instruction set: MRET (exists in latest L3 version), SRET (S ext., exists in latest L3 version), URET (N ext., exists in latest L3 version) *)
-(* TODO: Most important extensions: A (atomics), C (compressed) *)
-(* TODO: Are NOPs in riscv_stepLib correct? *)
-(* TODO: Take second look at stepLib code for Sail model (test.sml) *)
 
 (* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! *)
 (* Upon BILED_lifting_failed exception, debug from
@@ -167,13 +157,20 @@ val _ = print_msg "\n";
   (* Store the word (32 least significant bits) in x14 to the
    * memory address in x2 with offset 8 *)
   (* For offset zero ("SW x14,x2"):
-     Hex : 00E12023 
      Bin : 0000000 01110 00010 010 00000 0100011
 
      riscv_test_hex "00E12023";
 
    *)
   val _ = riscv_test_hex_print_asm "SW x14, 8(x2)" "00E12423";
+
+  (* Usage of the zero register: ("SW x0, 0(t2)"):
+     Bin : 0000000 00000 00111 010 00000 0100011
+
+     riscv_test_hex "00E12023";
+
+   *)
+  val _ = riscv_test_hex_print_asm "SW x0, 0(t2)" "0003A023";
 
 (* I-format (opcode OP-IMM) *)
   val _ = riscv_test_asms [
@@ -428,7 +425,7 @@ val _ = print_msg "\n";
 val _ = print_header "RV32A Standard Extension\n";
 val _ = print_msg "\n";
 
-(* TODO: LR/SC *)
+(* TODO: LR/SC assembler integration *)
 (* TODO: Unsure about ASM representation *)
 (* Binary: 00010 0 0 00000 00010 010 00001 0101111
 val amo_res = riscv_test_hex_mc "100120AF";


### PR DESCRIPTION
There was a problem with lifting RISC-V stores that store the value in `x0`. This PR resolves the problem, and fixes/leaves some additional debugging lines.